### PR TITLE
add speed limit to reduce robot speed if desired

### DIFF
--- a/example_robot/constants.py
+++ b/example_robot/constants.py
@@ -83,6 +83,13 @@ op_data = {
     "max_speed": 4.5 * (u.m / u.s),
     "max_angular_velocity": 11.5 * (u.rad / u.s),
 
+    # You can limit how fast your robot moves (e.g. during testing) using the
+    # following parameters.  Setting to None is the same as setting to
+    # max_speed/max_angular_velocity, and indicates no limit.
+    #
+    "speed_limit": 1.0 * (u.m / u.s),
+    "angular_velocity_limit": 2.5 * (u.rad / u.s),
+
     # For NEO / SparkMAX, use the following and comment out the Falcon500 values
     # "propulsion_neutral": rev.CANSparkMax.IdleMode.kCoast,
     # "steering_neutral": rev.CANSparkMax.IdleMode.kBrake,


### PR DESCRIPTION
The `max_speed` param is the maximum speed that the robot is capable of.  This is used e.g. to calculate open-loop motor percentages as desired_speed/max_speed.

However, it is useful to be able to set a "speed limit" for the drive train, especially for testing, but also when training a new driver.  Since this can't be done simply by adjusting max_speed, a new param is required.

The easiest way to apply a speed limit is by adjusting joystick input.  This doesn't apply the speed limit to autonomous behavior, but that might be acceptable.  (If not... future work!)  This implementation applies any exponential (e.g. squaring, for better low-speed control) to the joystick input first, and then uses the speed limit as the maximum for the exponent-controlled joystick input.  Users still get the UX of the adjusted `process_joystick_input()` method.

The angular velocity limit is a limit on robot spinning-in-place speed, not a limit on how quickly the azimuth motors can run.  There may be a better way to express this.

Please let me know your thoughts on this PR.